### PR TITLE
Audit fixes: crypto rewrite + crash/security/UI bugs

### DIFF
--- a/app/src/main/java/com/hereliesaz/barcodencrypt/crypto/EncryptionManager.kt
+++ b/app/src/main/java/com/hereliesaz/barcodencrypt/crypto/EncryptionManager.kt
@@ -8,13 +8,14 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * High-level v5 crypto entry point. Stateless façade over [RatchetEngine] +
- * [RatchetStateRepository].
+ * High-level v6 crypto entry point. Stateless façade over [RatchetEngine] +
+ * [RatchetStateRepository] that owns the Argon2id bootstrap.
  *
- * Bootstrap (first encrypt/decrypt for a contact) runs Argon2id over the barcode and
- * optional password to derive the root key; subsequent calls advance the symmetric
- * chain and persist the updated [RatchetState]. The DH ratchet engages when Plan 4's
- * QR key-exchange UI lands; until then both sides ride the symmetric chain.
+ * On the first send to a contact we generate a random per-contact salt, derive the
+ * Argon2 bootstrap key over `(barcode ‖ password, salt)`, and seed a sending chain. The
+ * salt rides in every outbound header. On receive we read the peer's salt from the
+ * header and seed (or re-seed) the receiving chain from the matching Argon2 key, so both
+ * sides derive identical message keys.
  */
 @Singleton
 class EncryptionManager @Inject constructor(
@@ -30,7 +31,8 @@ class EncryptionManager @Inject constructor(
         ttlMs: Long? = null,
         openMax: Int? = null,
     ): String? {
-        val (salt, state) = loadOrBootstrap(contactLookupKey, barcode, password) ?: return null
+        val barcodeValue = resolveBarcodeValue(barcode) ?: return null
+        val state = loadOrBootstrapSending(contactLookupKey, barcodeValue, password)
         val contactIdHash = contactIdHashFor(contactLookupKey)
         val (newState, envelope) = RatchetEngine.encrypt(
             state = state,
@@ -39,7 +41,7 @@ class EncryptionManager @Inject constructor(
             ttlMs = ttlMs,
             openMax = openMax,
         )
-        ratchetStateRepository.save(contactLookupKey, salt, newState)
+        ratchetStateRepository.save(contactLookupKey, newState)
         return envelope
     }
 
@@ -49,17 +51,25 @@ class EncryptionManager @Inject constructor(
         barcode: Barcode,
         password: String? = null,
     ): String? {
-        val (salt, state) = loadOrBootstrap(contactLookupKey, barcode, password) ?: return null
+        val payload = MessageEnvelope.decode(envelope) ?: return null
+        val header = runCatching { MessageHeader.decode(payload) }.getOrNull() ?: return null
+        val barcodeValue = resolveBarcodeValue(barcode) ?: return null
+
+        var state = loadOrBootstrapSending(contactLookupKey, barcodeValue, password)
+        if (RatchetEngine.needsReceivingBootstrap(state, header.salt)) {
+            val recvKey = deriveBootstrapKey(barcodeValue, password, header.salt)
+            state = RatchetEngine.bootstrapReceiving(state, recvKey, header.salt)
+        }
+
         val (newState, plaintext) = RatchetEngine.decrypt(state, envelope) ?: return null
-        ratchetStateRepository.save(contactLookupKey, salt, newState)
+        ratchetStateRepository.save(contactLookupKey, newState)
         return String(plaintext, Charsets.UTF_8)
     }
 
     /**
-     * Backwards-compatible signature retained for the existing
-     * [com.hereliesaz.barcodencrypt.viewmodel.EncryptionOverlayViewModel] callsite,
-     * which doesn't yet have a contact context. Returns null until Plan 4 threads the
-     * contact through the overlay flow.
+     * Backwards-compatible signature retained for the
+     * [com.hereliesaz.barcodencrypt.viewmodel.EncryptionOverlayViewModel] callsite, which
+     * doesn't yet have a contact context. Falls back to the barcode's own contact.
      */
     @Deprecated(
         message = "Pass a contactLookupKey. Plan 4 will thread it through the overlay.",
@@ -80,26 +90,31 @@ class EncryptionManager @Inject constructor(
         openMax = openCount,
     )
 
-    private suspend fun loadOrBootstrap(
+    private suspend fun loadOrBootstrapSending(
         contactLookupKey: String,
-        barcode: Barcode,
+        barcodeValue: String,
         password: String?,
-    ): Pair<ByteArray, RatchetState>? {
+    ): RatchetState {
         ratchetStateRepository.load(contactLookupKey)?.let { return it }
-        // First encrypt/decrypt for this contact: bootstrap a fresh state.
-        val barcodeValue = barcode.value.takeIf { it.isNotEmpty() } ?: run {
+        val sendSalt = ByteArray(MessageHeader.SALT_SIZE).also { random.nextBytes(it) }
+        val bootstrapKey = deriveBootstrapKey(barcodeValue, password, sendSalt)
+        val state = RatchetEngine.bootstrapSending(bootstrapKey, sendSalt)
+        ratchetStateRepository.save(contactLookupKey, state)
+        return state
+    }
+
+    private fun deriveBootstrapKey(barcodeValue: String, password: String?, salt: ByteArray): ByteArray {
+        val keyMaterial = barcodeValue.toByteArray(Charsets.UTF_8) +
+            (password?.toByteArray(Charsets.UTF_8) ?: ByteArray(0))
+        return Argon2.derive(keyMaterial, salt)
+    }
+
+    private fun resolveBarcodeValue(barcode: Barcode): String? {
+        val value = barcode.value.takeIf { it.isNotEmpty() } ?: run {
             barcode.decryptValue()
             barcode.value
         }
-        if (barcodeValue.isEmpty()) return null
-        val salt = ByteArray(SALT_SIZE).also { random.nextBytes(it) }
-        val state = RatchetEngine.bootstrap(
-            barcode = barcodeValue.toByteArray(Charsets.UTF_8),
-            password = password?.toByteArray(Charsets.UTF_8),
-            contactSalt = salt,
-        )
-        ratchetStateRepository.save(contactLookupKey, salt, state)
-        return salt to state
+        return value.takeIf { it.isNotEmpty() }
     }
 
     private fun contactIdHashFor(contactLookupKey: String): ByteArray {
@@ -109,9 +124,5 @@ class EncryptionManager @Inject constructor(
         return ByteArray(MessageHeader.CONTACT_ID_HASH_SIZE) { i ->
             hex.substring(i * 2, i * 2 + 2).toInt(16).toByte()
         }
-    }
-
-    companion object {
-        private const val SALT_SIZE = 16
     }
 }

--- a/app/src/main/java/com/hereliesaz/barcodencrypt/crypto/MessageEnvelope.kt
+++ b/app/src/main/java/com/hereliesaz/barcodencrypt/crypto/MessageEnvelope.kt
@@ -1,22 +1,26 @@
 package com.hereliesaz.barcodencrypt.crypto
 
-import android.util.Base64
+import java.util.Base64
 
 /**
- * Wire-format wrapper around a binary v5 payload (header || ciphertext).
+ * Wire-format wrapper around a binary v6 payload (header || ciphertext).
  *
- * Encodes as `~BCEv5~<base64>`. The base64 is URL-safe + no-wrap so the token survives
- * chat clients that line-wrap or smart-quote pasted text.
+ * Encodes as `~BCEv6~<base64>`. The base64 uses the URL-safe alphabet with no padding so
+ * the token survives chat clients that line-wrap or smart-quote pasted text. Uses
+ * [java.util.Base64] (available since API 26 = our minSdk) rather than `android.util`, so
+ * the crypto path is exercised by JVM unit tests.
  */
 object MessageEnvelope {
-    const val PREFIX = "~BCEv5~"
-    private const val BASE64_FLAGS = Base64.NO_WRAP or Base64.URL_SAFE or Base64.NO_PADDING
+    const val PREFIX = "~BCEv6~"
+
+    private val encoder = Base64.getUrlEncoder().withoutPadding()
+    private val decoder = Base64.getUrlDecoder()
 
     fun encode(payload: ByteArray): String =
-        PREFIX + Base64.encodeToString(payload, BASE64_FLAGS)
+        PREFIX + encoder.encodeToString(payload)
 
     fun decode(token: String): ByteArray? {
         if (!token.startsWith(PREFIX)) return null
-        return runCatching { Base64.decode(token.removePrefix(PREFIX), BASE64_FLAGS) }.getOrNull()
+        return runCatching { decoder.decode(token.removePrefix(PREFIX)) }.getOrNull()
     }
 }

--- a/app/src/main/java/com/hereliesaz/barcodencrypt/crypto/MessageHeader.kt
+++ b/app/src/main/java/com/hereliesaz/barcodencrypt/crypto/MessageHeader.kt
@@ -1,52 +1,51 @@
 package com.hereliesaz.barcodencrypt.crypto
 
+import java.nio.BufferUnderflowException
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
 /**
- * Binary header carried alongside every v5 ciphertext.
+ * Binary header carried alongside every v6 ciphertext.
  *
  * Wire layout (big-endian, see `docs/crypto/wire-format.md`):
  *
  * ```
- * magic[4] = "BCE5"
- * version[1] = 0x05
+ * magic[4] = "BCE6"
+ * version[1] = 0x06
  * flags[1]   = bit 0: has_ttl, bit 1: has_open_count, bit 2: dh_ratchet_step
  * contactIdHash[16]
+ * salt[16]                  the sender's per-contact Argon2 salt
  * dhPublic[32]
  * previousChainMessages[4]
  * messageNumber[4]
  * ttlMs[8]              (present iff flags.0)
  * openCountMax[4]       (present iff flags.1)
  * timestampMs[8]
- * nonce[12]
  * ```
  *
- * The whole encoded header (magic..nonce, inclusive) is fed to AES-GCM as
- * `associatedData`, so flipping any bit there fails the GCM tag.
+ * The whole encoded header is fed to AES-GCM as `associatedData`, so flipping any bit
+ * there fails the GCM tag. The 96-bit GCM IV is generated randomly by the AEAD and is
+ * carried at the front of the ciphertext, not in this header.
  */
 data class MessageHeader(
     val contactIdHash: ByteArray,
+    val salt: ByteArray,
     val dhPublic: ByteArray,
     val previousChainMessages: Int,
     val messageNumber: Int,
     val ttlMs: Long?,
     val openCountMax: Int?,
     val timestampMs: Long,
-    val nonce: ByteArray,
     val dhRatchetStep: Boolean,
 ) {
     init {
         require(contactIdHash.size == CONTACT_ID_HASH_SIZE)
+        require(salt.size == SALT_SIZE)
         require(dhPublic.size == DH_PUBLIC_SIZE)
-        require(nonce.size == NONCE_SIZE)
     }
 
     fun encode(): ByteArray {
-        var size = HEADER_FIXED_SIZE
-        if (ttlMs != null) size += TTL_SIZE
-        if (openCountMax != null) size += OPEN_COUNT_SIZE
-        val buf = ByteBuffer.allocate(size).order(ByteOrder.BIG_ENDIAN)
+        val buf = ByteBuffer.allocate(encodedSize()).order(ByteOrder.BIG_ENDIAN)
         buf.put(MAGIC)
         buf.put(VERSION)
         var flags = 0
@@ -55,13 +54,13 @@ data class MessageHeader(
         if (dhRatchetStep) flags = flags or FLAG_DH_RATCHET_STEP
         buf.put(flags.toByte())
         buf.put(contactIdHash)
+        buf.put(salt)
         buf.put(dhPublic)
         buf.putInt(previousChainMessages)
         buf.putInt(messageNumber)
         if (ttlMs != null) buf.putLong(ttlMs)
         if (openCountMax != null) buf.putInt(openCountMax)
         buf.putLong(timestampMs)
-        buf.put(nonce)
         return buf.array()
     }
 
@@ -76,48 +75,48 @@ data class MessageHeader(
         if (this === other) return true
         if (other !is MessageHeader) return false
         return contactIdHash.contentEquals(other.contactIdHash) &&
+            salt.contentEquals(other.salt) &&
             dhPublic.contentEquals(other.dhPublic) &&
             previousChainMessages == other.previousChainMessages &&
             messageNumber == other.messageNumber &&
             ttlMs == other.ttlMs &&
             openCountMax == other.openCountMax &&
             timestampMs == other.timestampMs &&
-            nonce.contentEquals(other.nonce) &&
             dhRatchetStep == other.dhRatchetStep
     }
 
     override fun hashCode(): Int {
         var r = contactIdHash.contentHashCode()
+        r = 31 * r + salt.contentHashCode()
         r = 31 * r + dhPublic.contentHashCode()
         r = 31 * r + previousChainMessages
         r = 31 * r + messageNumber
         r = 31 * r + (ttlMs?.hashCode() ?: 0)
         r = 31 * r + (openCountMax ?: 0)
         r = 31 * r + timestampMs.hashCode()
-        r = 31 * r + nonce.contentHashCode()
         r = 31 * r + dhRatchetStep.hashCode()
         return r
     }
 
     companion object {
-        private val MAGIC = "BCE5".toByteArray(Charsets.US_ASCII)
-        private const val VERSION: Byte = 0x05
+        private val MAGIC = "BCE6".toByteArray(Charsets.US_ASCII)
+        private const val VERSION: Byte = 0x06
 
         private const val MAGIC_SIZE = 4
         private const val VERSION_SIZE = 1
         private const val FLAGS_SIZE = 1
         const val CONTACT_ID_HASH_SIZE = 16
+        const val SALT_SIZE = 16
         const val DH_PUBLIC_SIZE = 32
         private const val PREV_N_SIZE = 4
         private const val MESSAGE_NUMBER_SIZE = 4
         private const val TIMESTAMP_SIZE = 8
-        const val NONCE_SIZE = 12
         private const val TTL_SIZE = 8
         private const val OPEN_COUNT_SIZE = 4
 
         const val HEADER_FIXED_SIZE = MAGIC_SIZE + VERSION_SIZE + FLAGS_SIZE +
-            CONTACT_ID_HASH_SIZE + DH_PUBLIC_SIZE + PREV_N_SIZE +
-            MESSAGE_NUMBER_SIZE + TIMESTAMP_SIZE + NONCE_SIZE
+            CONTACT_ID_HASH_SIZE + SALT_SIZE + DH_PUBLIC_SIZE + PREV_N_SIZE +
+            MESSAGE_NUMBER_SIZE + TIMESTAMP_SIZE
 
         const val FLAG_HAS_TTL = 0x1
         const val FLAG_HAS_OPEN_COUNT = 0x2
@@ -134,25 +133,37 @@ data class MessageHeader(
             val hasTtl = flags and FLAG_HAS_TTL != 0
             val hasOpenCount = flags and FLAG_HAS_OPEN_COUNT != 0
             val dhStep = flags and FLAG_DH_RATCHET_STEP != 0
-            val contactIdHash = ByteArray(CONTACT_ID_HASH_SIZE).also { buf.get(it) }
-            val dhPublic = ByteArray(DH_PUBLIC_SIZE).also { buf.get(it) }
-            val prevN = buf.int
-            val n = buf.int
-            val ttl = if (hasTtl) buf.long else null
-            val openMax = if (hasOpenCount) buf.int else null
-            val timestamp = buf.long
-            val nonce = ByteArray(NONCE_SIZE).also { buf.get(it) }
-            return MessageHeader(
-                contactIdHash = contactIdHash,
-                dhPublic = dhPublic,
-                previousChainMessages = prevN,
-                messageNumber = n,
-                ttlMs = ttl,
-                openCountMax = openMax,
-                timestampMs = timestamp,
-                nonce = nonce,
-                dhRatchetStep = dhStep,
-            )
+
+            // Make sure the buffer is large enough for the optional fields the flags claim
+            // are present, so the reads below can't run off the end.
+            val required = HEADER_FIXED_SIZE +
+                (if (hasTtl) TTL_SIZE else 0) +
+                (if (hasOpenCount) OPEN_COUNT_SIZE else 0)
+            require(bytes.size >= required) { "header truncated for declared flags" }
+
+            return try {
+                val contactIdHash = ByteArray(CONTACT_ID_HASH_SIZE).also { buf.get(it) }
+                val salt = ByteArray(SALT_SIZE).also { buf.get(it) }
+                val dhPublic = ByteArray(DH_PUBLIC_SIZE).also { buf.get(it) }
+                val prevN = buf.int
+                val n = buf.int
+                val ttl = if (hasTtl) buf.long else null
+                val openMax = if (hasOpenCount) buf.int else null
+                val timestamp = buf.long
+                MessageHeader(
+                    contactIdHash = contactIdHash,
+                    salt = salt,
+                    dhPublic = dhPublic,
+                    previousChainMessages = prevN,
+                    messageNumber = n,
+                    ttlMs = ttl,
+                    openCountMax = openMax,
+                    timestampMs = timestamp,
+                    dhRatchetStep = dhStep,
+                )
+            } catch (e: BufferUnderflowException) {
+                throw IllegalArgumentException("header truncated", e)
+            }
         }
     }
 }

--- a/app/src/main/java/com/hereliesaz/barcodencrypt/crypto/RatchetEngine.kt
+++ b/app/src/main/java/com/hereliesaz/barcodencrypt/crypto/RatchetEngine.kt
@@ -3,75 +3,73 @@ package com.hereliesaz.barcodencrypt.crypto
 import com.google.crypto.tink.subtle.AesGcmJce
 import com.google.crypto.tink.subtle.Hkdf
 import com.google.crypto.tink.subtle.X25519
-import javax.crypto.Mac
-import javax.crypto.spec.SecretKeySpec
 
 /**
- * Pure-function v5 Double Ratchet implementation.
+ * Pure-function v6 ratchet implementation. No Android/IO/Argon2 dependencies — the
+ * Argon2id bootstrap key is computed by the caller ([EncryptionManager]) and handed in,
+ * so everything here is unit-testable on the JVM.
  *
- * Symmetric path (always available): the chain key advances on every encrypt/decrypt,
- * the message key is HKDF-derived from the chain key, and the AES-GCM nonce is
- * deterministically derived from the message key and message number. The whole header
- * is fed to GCM as `associatedData` so tampering with TTL, openCount, dhPublic, n, or
- * any other field fails the tag check.
+ * Symmetric path (always available): both peers derive the *same* chain from the *same*
+ * `Argon2(barcode, salt)` bootstrap key, so the sender's chain key for message `n` equals
+ * the receiver's chain key for message `n`. The sender carries its salt in every header;
+ * the receiver bootstraps the matching receiving chain from it. Because each peer uses its
+ * own salt, the two directions are independent and never collide.
  *
- * DH path (engaged via [startSession]): each fresh sending chain begins by mixing in
- * `DH(self_private, remote_public)` into the root key via [kdfRk]. A peer detecting an
- * unseen `dhPublic` in an incoming header advances its own DH ratchet first (via
- * [dhRatchetReceive]) before processing the message.
+ * The AES-GCM message key is HKDF-derived from the chain key, which advances on every
+ * encrypt and decrypt. The whole header is fed to GCM as `associatedData`, and the 96-bit
+ * GCM IV is generated randomly by the AEAD (carried at the front of the ciphertext).
  *
- * Out-of-order delivery is supported within [SKIP_WINDOW] messages per chain. Any keys
- * skipped past are retained in [RatchetState.skipped] with FIFO eviction at the
- * window cap.
- *
- * No Android/IO dependencies — everything is unit-testable on the JVM.
+ * Out-of-order delivery is supported within [SKIP_WINDOW] messages per chain; keys skipped
+ * past are retained in [RatchetState.skipped] with FIFO eviction at the window cap.
  */
 object RatchetEngine {
 
     private const val KEY_SIZE = 32
     private const val MAC_ALG = "HMACSHA256"
-    private const val INFO_ROOT = "BCEv5_Root"
-    private const val INFO_SEND_CHAIN = "BCEv5_SendChain"
-    private const val INFO_RECV_CHAIN = "BCEv5_RecvChain"
-    private const val INFO_MESSAGE_KEY = "BCEv5_MessageKey"
-    private const val INFO_NEXT_CHAIN = "BCEv5_NextChain"
-    private const val INFO_NONCE = "BCEv5_Nonce"
-    private const val INFO_RK_CHAIN = "BCEv5_RkChain"
+    private const val INFO_ROOT = "BCEv6_Root"
+    private const val INFO_CHAIN = "BCEv6_Chain"
+    private const val INFO_MESSAGE_KEY = "BCEv6_MessageKey"
+    private const val INFO_NEXT_CHAIN = "BCEv6_NextChain"
+    private const val INFO_RK_CHAIN = "BCEv6_RkChain"
     const val SKIP_WINDOW = 1000
 
-    fun bootstrap(barcode: ByteArray, password: ByteArray?, contactSalt: ByteArray): RatchetState {
-        val keyMaterial = barcode + (password ?: ByteArray(0))
-        val bootstrapKey = Argon2.derive(keyMaterial, contactSalt)
+    /**
+     * Bootstraps the sending side from a pre-derived 32-byte Argon2 key and our own salt.
+     * The receiving side is left empty until the first inbound message reveals the peer's
+     * salt (see [bootstrapReceiving]).
+     */
+    fun bootstrapSending(bootstrapKey: ByteArray, sendSalt: ByteArray): RatchetState {
         val rk = hkdf(bootstrapKey, ByteArray(0), INFO_ROOT)
-        val cks = hkdf(bootstrapKey, ByteArray(0), INFO_SEND_CHAIN)
-        val ckr = hkdf(bootstrapKey, ByteArray(0), INFO_RECV_CHAIN)
+        val cks = hkdf(bootstrapKey, ByteArray(0), INFO_CHAIN)
         return RatchetState(
-            rk = rk, cks = cks, ckr = ckr,
-            dhSelfPriv = null, dhSelfPub = null, dhRemotePub = null,
-            ns = 0, nr = 0, pn = 0, skipped = emptyMap(),
+            sendSalt = sendSalt,
+            cks = cks,
+            ns = 0,
+            recvSalt = null,
+            ckr = null,
+            nr = 0,
+            skipped = emptyMap(),
+            rk = rk,
+            dhSelfPriv = null,
+            dhSelfPub = null,
+            dhRemotePub = null,
+            pn = 0,
         )
     }
 
     /**
-     * Engages the DH ratchet against an externally-supplied remote public key (e.g.
-     * Plan 4's QR key exchange). Generates a fresh X25519 keypair, computes the
-     * shared secret, mixes it into the root key, and seeds a new sending chain.
+     * (Re)seeds the receiving chain from the peer's salt and the matching Argon2 key. Any
+     * previously stashed skipped keys (which belonged to the old receiving chain) are
+     * dropped, since they can no longer be derived from the new chain.
      */
-    fun startSession(state: RatchetState, remotePublic: ByteArray): RatchetState {
-        val priv = X25519.generatePrivateKey()
-        val pub = X25519.publicFromPrivate(priv)
-        val shared = X25519.computeSharedSecret(priv, remotePublic)
-        val (newRk, sendingChain) = kdfRk(state.rk, shared)
-        return state.copy(
-            rk = newRk,
-            cks = sendingChain,
-            ckr = null,
-            dhSelfPriv = priv,
-            dhSelfPub = pub,
-            dhRemotePub = remotePublic,
-            ns = 0, nr = 0, pn = state.ns,
-        )
+    fun bootstrapReceiving(state: RatchetState, recvBootstrapKey: ByteArray, recvSalt: ByteArray): RatchetState {
+        val ckr = hkdf(recvBootstrapKey, ByteArray(0), INFO_CHAIN)
+        return state.copy(recvSalt = recvSalt, ckr = ckr, nr = 0, skipped = emptyMap())
     }
+
+    /** True when the receiving chain is missing or seeded from a different salt. */
+    fun needsReceivingBootstrap(state: RatchetState, headerSalt: ByteArray): Boolean =
+        state.ckr == null || state.recvSalt == null || !state.recvSalt.contentEquals(headerSalt)
 
     fun encrypt(
         state: RatchetState,
@@ -83,21 +81,19 @@ object RatchetEngine {
     ): Pair<RatchetState, String> {
         val cks = requireNotNull(state.cks) { "sending chain not initialized" }
         val (nextCks, mk) = kdfCk(cks)
-        val nonce = deriveNonce(mk, state.ns)
         val header = MessageHeader(
             contactIdHash = contactIdHash,
+            salt = state.sendSalt,
             dhPublic = state.dhSelfPub ?: ByteArray(MessageHeader.DH_PUBLIC_SIZE),
             previousChainMessages = state.pn,
             messageNumber = state.ns,
             ttlMs = ttlMs,
             openCountMax = openMax,
             timestampMs = System.currentTimeMillis(),
-            nonce = nonce,
             dhRatchetStep = dhRatchetStep,
         )
         val headerBytes = header.encode()
-        val aead = AesGcmJce(mk)
-        val ciphertext = aead.encrypt(plaintext, headerBytes)
+        val ciphertext = AesGcmJce(mk).encrypt(plaintext, headerBytes)
         val payload = headerBytes + ciphertext
         val newState = state.copy(cks = nextCks, ns = state.ns + 1)
         return newState to MessageEnvelope.encode(payload)
@@ -114,8 +110,7 @@ object RatchetEngine {
             return null
         }
 
-        // If we have a DH ratchet engaged and the peer has rotated their key,
-        // advance our DH ratchet before processing the message.
+        // If the DH ratchet is engaged and the peer rotated their key, advance first.
         var workingState = state
         val peerHasNewDh = workingState.dhSelfPriv != null && workingState.dhRemotePub != null &&
             !header.dhPublic.contentEquals(workingState.dhRemotePub) &&
@@ -136,7 +131,7 @@ object RatchetEngine {
         }
 
         // Otherwise advance the receiving chain, stashing any keys we step over.
-        var ckr = requireNotNull(workingState.ckr) { "receiving chain not initialized" }
+        var ckr = workingState.ckr ?: return null
         var nr = workingState.nr
         val newSkipped = workingState.skipped.toMutableMap()
         if (header.messageNumber < nr) return null  // replay or stale
@@ -153,20 +148,39 @@ object RatchetEngine {
             }
         }
         val (nextCkr, mk) = kdfCk(ckr)
-        ckr = nextCkr
-        nr += 1
 
+        // Authenticate before committing the advanced chain so a forged ciphertext can't
+        // ratchet our state forward.
         val plain = runCatching { AesGcmJce(mk).decrypt(ciphertext, headerBytes) }.getOrNull()
             ?: return null
 
-        return workingState.copy(ckr = ckr, nr = nr, skipped = newSkipped) to plain
+        return workingState.copy(ckr = nextCkr, nr = nr + 1, skipped = newSkipped) to plain
     }
 
     /**
-     * Handles an incoming DH ratchet step from the peer: derives a new receiving chain
-     * from the peer's freshly-rotated public key, then rotates our own ephemeral keys
-     * and seeds a new sending chain.
+     * Engages the DH ratchet against an externally-supplied remote public key (Plan 4's
+     * QR key exchange). Generates a fresh X25519 keypair, mixes the shared secret into the
+     * root key, and seeds a new sending chain.
      */
+    fun startSession(state: RatchetState, remotePublic: ByteArray): RatchetState {
+        val priv = X25519.generatePrivateKey()
+        val pub = X25519.publicFromPrivate(priv)
+        val shared = X25519.computeSharedSecret(priv, remotePublic)
+        val (newRk, sendingChain) = kdfRk(state.rk, shared)
+        return state.copy(
+            rk = newRk,
+            cks = sendingChain,
+            ckr = null,
+            recvSalt = null,
+            dhSelfPriv = priv,
+            dhSelfPub = pub,
+            dhRemotePub = remotePublic,
+            ns = 0,
+            nr = 0,
+            pn = state.ns,
+        )
+    }
+
     private fun dhRatchetReceive(state: RatchetState, remotePublic: ByteArray): RatchetState {
         val privExisting = requireNotNull(state.dhSelfPriv) {
             "cannot receive DH ratchet step before session is started"
@@ -205,17 +219,4 @@ object RatchetEngine {
 
     private fun hkdf(ikm: ByteArray, salt: ByteArray, info: String): ByteArray =
         Hkdf.computeHkdf(MAC_ALG, ikm, salt, info.toByteArray(), KEY_SIZE)
-
-    private fun deriveNonce(mk: ByteArray, n: Int): ByteArray {
-        val mac = Mac.getInstance(MAC_ALG)
-        mac.init(SecretKeySpec(mk, MAC_ALG))
-        val nBytes = byteArrayOf(
-            (n ushr 24).toByte(),
-            (n ushr 16).toByte(),
-            (n ushr 8).toByte(),
-            n.toByte(),
-        )
-        val full = mac.doFinal(INFO_NONCE.toByteArray() + nBytes)
-        return full.copyOf(MessageHeader.NONCE_SIZE)
-    }
 }

--- a/app/src/main/java/com/hereliesaz/barcodencrypt/crypto/RatchetState.kt
+++ b/app/src/main/java/com/hereliesaz/barcodencrypt/crypto/RatchetState.kt
@@ -1,38 +1,83 @@
 package com.hereliesaz.barcodencrypt.crypto
 
 /**
- * Immutable snapshot of one side of a Signal-style double ratchet, scoped to a contact.
+ * Immutable snapshot of one side of the v6 ratchet, scoped to a contact.
  *
- * Field naming matches the Signal spec:
- * - `rk`              root key
- * - `cks`             sending chain key
- * - `ckr`             receiving chain key
- * - `dhSelfPriv/Pub`  our current X25519 ephemeral keypair (null until the DH ratchet
- *                     is engaged via [RatchetEngine.startSession])
- * - `dhRemotePub`     the latest X25519 public key we have received from the peer
- * - `ns`              messages sent under the current sending chain
- * - `nr`              messages received under the current receiving chain
- * - `pn`              messages that were sent under the *previous* sending chain
- *                     before the last DH ratchet step (needed to derive skipped keys
- *                     for in-flight messages from the prior chain)
- * - `skipped`         bounded map of `(dhPublic, messageNumber) → mk` for messages we
- *                     advanced past without seeing yet
+ * The symmetric path is bidirectional: each device owns an independent *sending* chain
+ * seeded from its own random [sendSalt], and tracks the peer's *receiving* chain seeded
+ * from the [recvSalt] it learns from the first inbound message. Because the two salts
+ * differ, the two directions never collide on a message key even though both start at
+ * message number 0.
+ *
+ * - `sendSalt`         our per-contact Argon2 salt; transmitted in every outbound header
+ * - `cks`              our sending chain key (HKDF of `Argon2(barcode, sendSalt)`)
+ * - `ns`               messages sent under the current sending chain
+ * - `recvSalt`         the peer's Argon2 salt, learned from inbound headers (null until
+ *                      the first message is received)
+ * - `ckr`              the peer's receiving chain key (null until `recvSalt` is known)
+ * - `nr`               messages received under the current receiving chain
+ * - `skipped`          bounded map of `(dhPublic, messageNumber) → mk` for messages we
+ *                      advanced past without seeing yet
+ * - `rk`               root key (used by the optional DH ratchet path)
+ * - `dhSelfPriv/Pub`   our current X25519 ephemeral keypair (null until the DH ratchet
+ *                      is engaged via [RatchetEngine.startSession])
+ * - `dhRemotePub`      the latest X25519 public key we have received from the peer
+ * - `pn`               messages sent under the *previous* sending chain before the last
+ *                      DH ratchet step
  */
 data class RatchetState(
-    val rk: ByteArray,
+    val sendSalt: ByteArray,
     val cks: ByteArray?,
+    val ns: Int,
+    val recvSalt: ByteArray?,
     val ckr: ByteArray?,
+    val nr: Int,
+    val skipped: Map<SkippedKeyId, ByteArray>,
+    val rk: ByteArray,
     val dhSelfPriv: ByteArray?,
     val dhSelfPub: ByteArray?,
     val dhRemotePub: ByteArray?,
-    val ns: Int,
-    val nr: Int,
     val pn: Int,
-    val skipped: Map<SkippedKeyId, ByteArray>,
 ) {
     init {
         require(rk.size == 32) { "rk must be 32 bytes" }
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is RatchetState) return false
+        return sendSalt.contentEquals(other.sendSalt) &&
+            nullableContentEquals(cks, other.cks) &&
+            ns == other.ns &&
+            nullableContentEquals(recvSalt, other.recvSalt) &&
+            nullableContentEquals(ckr, other.ckr) &&
+            nr == other.nr &&
+            skipped == other.skipped &&
+            rk.contentEquals(other.rk) &&
+            nullableContentEquals(dhSelfPriv, other.dhSelfPriv) &&
+            nullableContentEquals(dhSelfPub, other.dhSelfPub) &&
+            nullableContentEquals(dhRemotePub, other.dhRemotePub) &&
+            pn == other.pn
+    }
+
+    override fun hashCode(): Int {
+        var r = sendSalt.contentHashCode()
+        r = 31 * r + (cks?.contentHashCode() ?: 0)
+        r = 31 * r + ns
+        r = 31 * r + (recvSalt?.contentHashCode() ?: 0)
+        r = 31 * r + (ckr?.contentHashCode() ?: 0)
+        r = 31 * r + nr
+        r = 31 * r + skipped.hashCode()
+        r = 31 * r + rk.contentHashCode()
+        r = 31 * r + (dhSelfPriv?.contentHashCode() ?: 0)
+        r = 31 * r + (dhSelfPub?.contentHashCode() ?: 0)
+        r = 31 * r + (dhRemotePub?.contentHashCode() ?: 0)
+        r = 31 * r + pn
+        return r
+    }
+
+    private fun nullableContentEquals(a: ByteArray?, b: ByteArray?): Boolean =
+        if (a == null || b == null) a === b else a.contentEquals(b)
 }
 
 data class SkippedKeyId(val dhPublic: ByteArray, val n: Int) {

--- a/app/src/main/java/com/hereliesaz/barcodencrypt/data/AppDatabase.kt
+++ b/app/src/main/java/com/hereliesaz/barcodencrypt/data/AppDatabase.kt
@@ -198,7 +198,6 @@ abstract class AppDatabase : RoomDatabase() {
                         // Last-resort safety net for installs with a schema older than the
                         // earliest registered migration (no <3 migrations exist): wipe and
                         // rebuild rather than crash-loop on open.
-                        .fallbackToDestructiveMigration(dropAllTables = true)
                         .build()
                     INSTANCE = instance
                     instance

--- a/app/src/main/java/com/hereliesaz/barcodencrypt/data/AppDatabase.kt
+++ b/app/src/main/java/com/hereliesaz/barcodencrypt/data/AppDatabase.kt
@@ -15,7 +15,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         OpenedMessage::class,
         RatchetStateEntity::class,
     ],
-    version = 11,
+    version = 12,
     exportSchema = false,
 )
 @TypeConverters(Converters::class)
@@ -130,22 +130,79 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Repairs the `barcodes` schema for the v6 entity and rebuilds `ratchet_state` for
+         * the v6 ratchet.
+         *
+         * `MIGRATION_8_9` recreated `barcodes` without the `passwordHash` and
+         * `barcodeSequence` columns the entity still declares, so upgraders that passed
+         * through it have a table that fails Room's schema validation. We re-add the
+         * columns only when missing (fresh v9+ installs already have them). The v5
+         * `ratchet_state` is dropped wholesale — v5 ciphertext was never decryptable, and
+         * v6 bootstraps fresh on the next encrypt/decrypt.
+         */
+        private val MIGRATION_11_12 = object : Migration(11, 12) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                val barcodeColumns = mutableSetOf<String>()
+                db.query("PRAGMA table_info(`barcodes`)").use { cursor ->
+                    val nameIdx = cursor.getColumnIndex("name")
+                    while (cursor.moveToNext()) {
+                        barcodeColumns.add(cursor.getString(nameIdx))
+                    }
+                }
+                if (!barcodeColumns.contains("passwordHash")) {
+                    db.execSQL("ALTER TABLE `barcodes` ADD COLUMN `passwordHash` TEXT")
+                }
+                if (!barcodeColumns.contains("barcodeSequence")) {
+                    db.execSQL("ALTER TABLE `barcodes` ADD COLUMN `barcodeSequence` TEXT")
+                }
+
+                db.execSQL("DROP TABLE IF EXISTS `ratchet_state`")
+                db.execSQL(
+                    """
+                    CREATE TABLE `ratchet_state` (
+                        `contactLookupKey` TEXT NOT NULL PRIMARY KEY,
+                        `sendSalt` BLOB NOT NULL,
+                        `cks` BLOB,
+                        `ns` INTEGER NOT NULL,
+                        `recvSalt` BLOB,
+                        `ckr` BLOB,
+                        `nr` INTEGER NOT NULL,
+                        `skippedJson` TEXT NOT NULL,
+                        `rk` BLOB NOT NULL,
+                        `dhSelfPriv` BLOB,
+                        `dhSelfPub` BLOB,
+                        `dhRemotePub` BLOB,
+                        `pn` INTEGER NOT NULL
+                    )
+                    """.trimIndent()
+                )
+            }
+        }
+
         fun getDatabase(context: Context, passphrase: CharSequence): AppDatabase {
             return INSTANCE ?: synchronized(this) {
-                val factory = net.sqlcipher.database.SupportFactory(passphrase.toString().toByteArray())
-                val instance = Room.databaseBuilder(
-                    context.applicationContext,
-                    AppDatabase::class.java,
-                    "barcodencrypt_database",
-                )
-                    .openHelperFactory(factory)
-                    .addMigrations(
-                        MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7,
-                        MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11,
+                INSTANCE ?: run {
+                    val factory = net.sqlcipher.database.SupportFactory(passphrase.toString().toByteArray())
+                    val instance = Room.databaseBuilder(
+                        context.applicationContext,
+                        AppDatabase::class.java,
+                        "barcodencrypt_database",
                     )
-                    .build()
-                INSTANCE = instance
-                instance
+                        .openHelperFactory(factory)
+                        .addMigrations(
+                            MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7,
+                            MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11,
+                            MIGRATION_11_12,
+                        )
+                        // Last-resort safety net for installs with a schema older than the
+                        // earliest registered migration (no <3 migrations exist): wipe and
+                        // rebuild rather than crash-loop on open.
+                        .fallbackToDestructiveMigration(dropAllTables = true)
+                        .build()
+                    INSTANCE = instance
+                    instance
+                }
             }
         }
 

--- a/app/src/main/java/com/hereliesaz/barcodencrypt/data/BarcodeDao.kt
+++ b/app/src/main/java/com/hereliesaz/barcodencrypt/data/BarcodeDao.kt
@@ -80,6 +80,12 @@ interface BarcodeDao {
     suspend fun getBarcode(barcodeId: Int): Barcode?
 
     /**
+     * Retrieves every stored barcode (encrypted values; callers decrypt as needed).
+     */
+    @Query("SELECT * FROM barcodes")
+    suspend fun getAllBarcodes(): List<Barcode>
+
+    /**
      * Increments the usage counter for a barcode.
      * Used for non-ratchet, counter-based encryption schemes.
      */

--- a/app/src/main/java/com/hereliesaz/barcodencrypt/data/BarcodeRepository.kt
+++ b/app/src/main/java/com/hereliesaz/barcodencrypt/data/BarcodeRepository.kt
@@ -150,4 +150,21 @@ class BarcodeRepository @Inject constructor(private val barcodeDao: BarcodeDao) 
         barcode?.decryptValue()
         return barcode
     }
+
+    /**
+     * Finds every stored barcode whose decrypted value exactly equals [rawValue].
+     *
+     * Used by the scanner to resolve which key(s) a freshly-scanned barcode unlocks.
+     * Matching on the real decrypted value (rather than a 6-char hash suffix of the
+     * display name) is collision-free; a barcode shared by multiple contacts yields
+     * multiple candidates, and the caller tries each. Rows that fail to decrypt (e.g.
+     * corrupt ciphertext) are skipped rather than aborting the search.
+     */
+    suspend fun findBarcodesByRawValue(rawValue: String): List<Barcode> =
+        barcodeDao.getAllBarcodes().filter { barcode ->
+            runCatching {
+                barcode.decryptValue()
+                barcode.value == rawValue
+            }.getOrDefault(false)
+        }
 }

--- a/app/src/main/java/com/hereliesaz/barcodencrypt/data/RatchetStateEntity.kt
+++ b/app/src/main/java/com/hereliesaz/barcodencrypt/data/RatchetStateEntity.kt
@@ -4,45 +4,64 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 
 /**
- * Persisted snapshot of a contact's [com.hereliesaz.barcodencrypt.crypto.RatchetState],
- * along with the per-contact Argon2id salt used to bootstrap that state.
+ * Persisted snapshot of a contact's [com.hereliesaz.barcodencrypt.crypto.RatchetState].
  *
- * `skippedJson` is a JSON object keyed by `base64(dhPublic):n` → `base64(mk)`. The
- * map is bounded to [com.hereliesaz.barcodencrypt.crypto.RatchetEngine.SKIP_WINDOW]
- * entries; eldest skipped keys are evicted on overflow.
+ * `sendSalt` is our own per-contact Argon2 salt; `recvSalt` is the peer's salt learned
+ * from inbound headers (null until the first message arrives). `skippedJson` is a JSON
+ * object keyed by `base64(dhPublic):n` → `base64(mk)`, bounded to
+ * [com.hereliesaz.barcodencrypt.crypto.RatchetEngine.SKIP_WINDOW] entries.
  */
 @Entity(tableName = "ratchet_state")
 data class RatchetStateEntity(
     @PrimaryKey val contactLookupKey: String,
-    val salt: ByteArray,
-    val rk: ByteArray,
+    val sendSalt: ByteArray,
     val cks: ByteArray?,
+    val ns: Int,
+    val recvSalt: ByteArray?,
     val ckr: ByteArray?,
+    val nr: Int,
+    val skippedJson: String,
+    val rk: ByteArray,
     val dhSelfPriv: ByteArray?,
     val dhSelfPub: ByteArray?,
     val dhRemotePub: ByteArray?,
-    val ns: Int,
-    val nr: Int,
     val pn: Int,
-    val skippedJson: String,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is RatchetStateEntity) return false
         return contactLookupKey == other.contactLookupKey &&
-            salt.contentEquals(other.salt) &&
+            sendSalt.contentEquals(other.sendSalt) &&
+            nullableContentEquals(cks, other.cks) &&
+            ns == other.ns &&
+            nullableContentEquals(recvSalt, other.recvSalt) &&
+            nullableContentEquals(ckr, other.ckr) &&
+            nr == other.nr &&
+            skippedJson == other.skippedJson &&
             rk.contentEquals(other.rk) &&
-            (cks?.contentEquals(other.cks ?: ByteArray(0)) == (other.cks != null || cks == null)) &&
-            ns == other.ns && nr == other.nr && pn == other.pn &&
-            skippedJson == other.skippedJson
+            nullableContentEquals(dhSelfPriv, other.dhSelfPriv) &&
+            nullableContentEquals(dhSelfPub, other.dhSelfPub) &&
+            nullableContentEquals(dhRemotePub, other.dhRemotePub) &&
+            pn == other.pn
     }
 
     override fun hashCode(): Int {
         var r = contactLookupKey.hashCode()
-        r = 31 * r + salt.contentHashCode()
-        r = 31 * r + rk.contentHashCode()
+        r = 31 * r + sendSalt.contentHashCode()
         r = 31 * r + (cks?.contentHashCode() ?: 0)
-        r = 31 * r + ns + nr + pn
+        r = 31 * r + ns
+        r = 31 * r + (recvSalt?.contentHashCode() ?: 0)
+        r = 31 * r + (ckr?.contentHashCode() ?: 0)
+        r = 31 * r + nr
+        r = 31 * r + skippedJson.hashCode()
+        r = 31 * r + rk.contentHashCode()
+        r = 31 * r + (dhSelfPriv?.contentHashCode() ?: 0)
+        r = 31 * r + (dhSelfPub?.contentHashCode() ?: 0)
+        r = 31 * r + (dhRemotePub?.contentHashCode() ?: 0)
+        r = 31 * r + pn
         return r
     }
+
+    private fun nullableContentEquals(a: ByteArray?, b: ByteArray?): Boolean =
+        if (a == null || b == null) a === b else a.contentEquals(b)
 }

--- a/app/src/main/java/com/hereliesaz/barcodencrypt/data/RatchetStateRepository.kt
+++ b/app/src/main/java/com/hereliesaz/barcodencrypt/data/RatchetStateRepository.kt
@@ -22,32 +22,32 @@ class RatchetStateRepository @Inject constructor(
     private val skippedMapType = object : TypeToken<Map<String, String>>() {}.type
     private val base64Flags = Base64.NO_WRAP
 
-    /** Loads `(salt, state)` for [contactKey] if any; null if no state exists yet. */
-    suspend fun load(contactKey: String): Pair<ByteArray, RatchetState>? {
+    /** Loads the [RatchetState] for [contactKey] if any; null if no state exists yet. */
+    suspend fun load(contactKey: String): RatchetState? {
         val e = dao.get(contactKey) ?: return null
-        val skippedRaw: Map<String, String> = gson.fromJson(e.skippedJson, skippedMapType) ?: emptyMap()
-        val skipped = skippedRaw.entries.associate { (k, v) ->
-            val idx = k.lastIndexOf(':')
-            val dh = Base64.decode(k.substring(0, idx), base64Flags)
-            val n = k.substring(idx + 1).toInt()
-            SkippedKeyId(dh, n) to Base64.decode(v, base64Flags)
-        }
-        val state = RatchetState(
-            rk = e.rk,
+        val skippedRaw: Map<String, String> =
+            runCatching { gson.fromJson<Map<String, String>>(e.skippedJson, skippedMapType) }
+                .getOrNull() ?: emptyMap()
+        val skipped = skippedRaw.entries.mapNotNull { (k, v) ->
+            parseSkippedEntry(k, v)
+        }.toMap()
+        return RatchetState(
+            sendSalt = e.sendSalt,
             cks = e.cks,
+            ns = e.ns,
+            recvSalt = e.recvSalt,
             ckr = e.ckr,
+            nr = e.nr,
+            skipped = skipped,
+            rk = e.rk,
             dhSelfPriv = e.dhSelfPriv,
             dhSelfPub = e.dhSelfPub,
             dhRemotePub = e.dhRemotePub,
-            ns = e.ns,
-            nr = e.nr,
             pn = e.pn,
-            skipped = skipped,
         )
-        return e.salt to state
     }
 
-    suspend fun save(contactKey: String, salt: ByteArray, state: RatchetState) {
+    suspend fun save(contactKey: String, state: RatchetState) {
         val skippedRaw = state.skipped.entries.associate { (id, mk) ->
             "${Base64.encodeToString(id.dhPublic, base64Flags)}:${id.n}" to
                 Base64.encodeToString(mk, base64Flags)
@@ -55,22 +55,34 @@ class RatchetStateRepository @Inject constructor(
         dao.upsert(
             RatchetStateEntity(
                 contactLookupKey = contactKey,
-                salt = salt,
-                rk = state.rk,
+                sendSalt = state.sendSalt,
                 cks = state.cks,
+                ns = state.ns,
+                recvSalt = state.recvSalt,
                 ckr = state.ckr,
+                nr = state.nr,
+                skippedJson = gson.toJson(skippedRaw),
+                rk = state.rk,
                 dhSelfPriv = state.dhSelfPriv,
                 dhSelfPub = state.dhSelfPub,
                 dhRemotePub = state.dhRemotePub,
-                ns = state.ns,
-                nr = state.nr,
                 pn = state.pn,
-                skippedJson = gson.toJson(skippedRaw),
             )
         )
     }
 
     suspend fun delete(contactKey: String) {
         dao.delete(contactKey)
+    }
+
+    private fun parseSkippedEntry(key: String, value: String): Pair<SkippedKeyId, ByteArray>? {
+        val idx = key.lastIndexOf(':')
+        if (idx <= 0 || idx == key.length - 1) return null
+        val n = key.substring(idx + 1).toIntOrNull() ?: return null
+        return runCatching {
+            val dh = Base64.decode(key.substring(0, idx), base64Flags)
+            val mk = Base64.decode(value, base64Flags)
+            SkippedKeyId(dh, n) to mk
+        }.getOrNull()
     }
 }

--- a/app/src/main/java/com/hereliesaz/barcodencrypt/util/MessageParser.kt
+++ b/app/src/main/java/com/hereliesaz/barcodencrypt/util/MessageParser.kt
@@ -6,14 +6,13 @@ import com.hereliesaz.barcodencrypt.crypto.MessageEnvelope
 /**
  * Detects v5 message envelopes inside arbitrary on-screen text.
  *
- * Token shape: `~BCEv5~<base64>` where the base64 is URL-safe + no-wrap + no-padding
- * (matches [MessageEnvelope]). The regex deliberately covers both the URL-safe and the
- * legacy non-URL-safe alphabets so we tolerate copy-paste from clients that may rewrite
- * `+`/`/` along the way.
+ * Token shape: `~BCEv6~<base64>` where the base64 is URL-safe + no-wrap + no-padding
+ * (matches [MessageEnvelope]). The regex matches exactly the URL-safe alphabet the
+ * envelope emits, so detected tokens always decode.
  */
 object MessageParser {
 
-    private val V5_REGEX = Regex("${Regex.escape(MessageEnvelope.PREFIX)}[A-Za-z0-9+/=_\\-]+")
+    private val V5_REGEX = Regex("${Regex.escape(MessageEnvelope.PREFIX)}[A-Za-z0-9_-]+")
 
     fun findAllV5Tokens(
         rootNode: AccessibilityNodeInfo,

--- a/app/src/main/java/com/hereliesaz/barcodencrypt/viewmodel/KeyExchangeViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/barcodencrypt/viewmodel/KeyExchangeViewModel.kt
@@ -46,15 +46,17 @@ class KeyExchangeViewModel @Inject constructor(
     val secureChannelReady: StateFlow<Boolean> = _secureChannelReady.asStateFlow()
 
     init {
+        // The placeholder QR content is constant, so render it once rather than on every
+        // contact emission (which would churn 512x512 bitmaps).
+        _qrCodeBitmap.value = renderPlaceholderQr()
         viewModelScope.launch {
             contactRepository.getContactByLookupKey(contactLookupKey).collect { contact ->
                 _contact.value = contact
                 _secureChannelReady.value =
-                    ratchetStateRepository.load(contactLookupKey)?.second?.dhRemotePub != null
+                    ratchetStateRepository.load(contactLookupKey)?.dhRemotePub != null
                 // TODO("Plan 4"): generate an X25519 ephemeral keypair via
                 // RatchetEngine.startSession(), persist its RatchetState, and emit the
-                // public key as a QR via the snippet below.
-                _qrCodeBitmap.value = renderPlaceholderQr()
+                // public key as a QR.
             }
         }
     }
@@ -70,7 +72,7 @@ class KeyExchangeViewModel @Inject constructor(
 
     private fun renderPlaceholderQr(): Bitmap? = runCatching {
         val writer = QRCodeWriter()
-        val matrix = writer.encode("BCEv5-placeholder", BarcodeFormat.QR_CODE, 512, 512)
+        val matrix = writer.encode("BCEv6-placeholder", BarcodeFormat.QR_CODE, 512, 512)
         Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.RGB_565).also { bmp ->
             for (x in 0 until matrix.width) {
                 for (y in 0 until matrix.height) {

--- a/app/src/main/java/com/hereliesaz/barcodencrypt/viewmodel/ScannerViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/barcodencrypt/viewmodel/ScannerViewModel.kt
@@ -7,9 +7,8 @@ import androidx.lifecycle.viewModelScope
 import com.hereliesaz.barcodencrypt.crypto.EncryptionManager
 import com.hereliesaz.barcodencrypt.data.BarcodeRepository
 import com.hereliesaz.barcodencrypt.data.ContactRepository
-import com.hereliesaz.barcodencrypt.data.KeyType
-import com.hereliesaz.barcodencrypt.util.Hashing
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -24,56 +23,41 @@ class ScannerViewModel @Inject constructor(
     val decryptionResult: LiveData<DecryptionResult> = _decryptionResult
 
     /**
-     * Attempts to decrypt a `~BCEv5~` envelope using the most recently-seen barcode
-     * that matches [scannedValue].
+     * Attempts to decrypt a `~BCEv6~` envelope with the freshly-scanned [scannedValue].
      *
-     * Until Plan 4 threads the originating contact through the scanner flow, we infer
-     * the contact by looking up the first barcode whose stored hash matches the
-     * scan. That is correct for `SINGLE_BARCODE` keys and sufficient as a v1.0 path.
+     * We resolve every stored barcode whose decrypted value equals the scan (a barcode
+     * shared across contacts can match more than one) and try each in turn. The first
+     * candidate that decrypts wins; only the correct contact's ratchet state will, so a
+     * mismatch simply moves on. Runs off the main thread because the underlying Argon2
+     * bootstrap is CPU/memory heavy.
      */
     fun decryptMessage(scannedValue: String, encryptedMessage: String) {
-        viewModelScope.launch {
-            val needle = Hashing.sha256(scannedValue)
-            // TODO("Plan 4"): look up the right barcode via an indexed query instead
-            // of iterating. For now the keys-per-contact count is small.
-            val barcode = findBarcodeForScan(scannedValue, needle)
-            if (barcode == null) {
+        viewModelScope.launch(Dispatchers.Default) {
+            val candidates = barcodeRepository.findBarcodesByRawValue(scannedValue)
+            if (candidates.isEmpty()) {
                 _decryptionResult.postValue(
                     DecryptionResult.Error("No key matches this barcode.")
                 )
                 return@launch
             }
-            val contactLookupKey = barcode.contactLookupKey
-            val password = if (barcode.keyType == KeyType.PASSWORD_PROTECTED_BARCODE) {
-                // TODO("Plan 4"): prompt the user; for v1.0 the overlay supplies it.
-                null
-            } else {
-                null
-            }
-            val plaintext = encryptionManager.decrypt(
-                envelope = encryptedMessage,
-                contactLookupKey = contactLookupKey,
-                barcode = barcode,
-                password = password,
-            )
-            if (plaintext != null) {
-                _decryptionResult.postValue(DecryptionResult.Success(plaintext))
-            } else {
-                _decryptionResult.postValue(
-                    DecryptionResult.Error("Decryption failed. Wrong key, expired, or already opened.")
+            for (barcode in candidates) {
+                val plaintext = encryptionManager.decrypt(
+                    envelope = encryptedMessage,
+                    contactLookupKey = barcode.contactLookupKey,
+                    barcode = barcode,
+                    // TODO("Plan 4"): prompt for the password on password-protected keys;
+                    // the overlay supplies it on the overlay flow.
+                    password = null,
                 )
+                if (plaintext != null) {
+                    _decryptionResult.postValue(DecryptionResult.Success(plaintext))
+                    return@launch
+                }
             }
+            _decryptionResult.postValue(
+                DecryptionResult.Error("Decryption failed. Wrong key, expired, or already opened.")
+            )
         }
-    }
-
-    private suspend fun findBarcodeForScan(
-        scannedValue: String,
-        needleHash: String,
-    ): com.hereliesaz.barcodencrypt.data.Barcode? {
-        // Cheap heuristic: the legacy v4 path stored sha256(value).takeLast(6) as the
-        // barcode's display name. So we look up by `getBarcodeByName("Key ending in...XXX")`.
-        val tail = needleHash.takeLast(6)
-        return barcodeRepository.getBarcodeByName("Key ending in...$tail")
     }
 
     fun resetDecryptionResult() {

--- a/app/src/test/java/com/hereliesaz/barcodencrypt/crypto/MessageHeaderTest.kt
+++ b/app/src/test/java/com/hereliesaz/barcodencrypt/crypto/MessageHeaderTest.kt
@@ -2,20 +2,19 @@ package com.hereliesaz.barcodencrypt.crypto
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Test
 
 class MessageHeaderTest {
 
     private val baseHeader = MessageHeader(
         contactIdHash = ByteArray(16) { 1 },
+        salt = ByteArray(16) { 3 },
         dhPublic = ByteArray(32) { 2 },
         previousChainMessages = 5,
         messageNumber = 7,
         ttlMs = 10_000L,
         openCountMax = 3,
         timestampMs = 1_716_300_000_000L,
-        nonce = ByteArray(12) { 9 },
         dhRatchetStep = false,
     )
 
@@ -23,14 +22,14 @@ class MessageHeaderTest {
     fun `round trip without TTL or openCount`() {
         val h = baseHeader.copy(ttlMs = null, openCountMax = null)
         val bytes = h.encode()
-        assertEquals(82, bytes.size)
+        assertEquals(86, bytes.size)
         assertEquals(h, MessageHeader.decode(bytes))
     }
 
     @Test
     fun `round trip with TTL and openCount`() {
         val bytes = baseHeader.encode()
-        assertEquals(94, bytes.size)
+        assertEquals(98, bytes.size)
         assertEquals(baseHeader, MessageHeader.decode(bytes))
     }
 
@@ -62,18 +61,27 @@ class MessageHeaderTest {
     }
 
     @Test
+    fun `decode rejects header truncated for declared flags`() {
+        // A header that claims TTL + openCount but is only the fixed length must be
+        // rejected rather than reading past the buffer.
+        val full = baseHeader.encode()
+        val truncated = full.copyOfRange(0, MessageHeader.HEADER_FIXED_SIZE)
+        assertNotNull(runCatching { MessageHeader.decode(truncated) }.exceptionOrNull())
+    }
+
+    @Test
     fun `init rejects wrong-size contactIdHash`() {
         assertNotNull(
             runCatching {
                 MessageHeader(
                     contactIdHash = ByteArray(8),
+                    salt = baseHeader.salt,
                     dhPublic = baseHeader.dhPublic,
                     previousChainMessages = 0,
                     messageNumber = 0,
                     ttlMs = null,
                     openCountMax = null,
                     timestampMs = 0L,
-                    nonce = baseHeader.nonce,
                     dhRatchetStep = false,
                 )
             }.exceptionOrNull(),

--- a/app/src/test/java/com/hereliesaz/barcodencrypt/crypto/RatchetEngineTest.kt
+++ b/app/src/test/java/com/hereliesaz/barcodencrypt/crypto/RatchetEngineTest.kt
@@ -1,0 +1,162 @@
+package com.hereliesaz.barcodencrypt.crypto
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Exercises the pure v6 ratchet. Argon2 is bypassed: `key(seed)` stands in for the
+ * 32-byte `Argon2(barcode, salt)` output, which both peers compute identically from the
+ * shared barcode and the salt carried in the header.
+ */
+class RatchetEngineTest {
+
+    private val contactIdHash = ByteArray(16) { 7 }
+
+    private fun key(seed: Int) = ByteArray(32) { seed.toByte() }
+    private fun salt(seed: Int) = ByteArray(16) { (seed + it).toByte() }
+
+    @Test
+    fun `cross-device round trip`() {
+        val aliceKey = key(1)
+        val aliceSalt = salt(1)
+        var alice = RatchetEngine.bootstrapSending(aliceKey, aliceSalt)
+        var bob = RatchetEngine.bootstrapSending(key(2), salt(2))
+
+        val (alice2, envelope) = RatchetEngine.encrypt(
+            alice, contactIdHash, "hello".toByteArray(), null, null,
+        )
+        alice = alice2
+
+        assertTrue(envelope.startsWith(MessageEnvelope.PREFIX))
+
+        // Bob learns Alice's salt from the header and seeds the receiving chain with the
+        // same Argon2 key. This is the case the old v5 code could never decrypt.
+        val header = MessageHeader.decode(MessageEnvelope.decode(envelope)!!)
+        assertArrayEquals(aliceSalt, header.salt)
+        assertTrue(RatchetEngine.needsReceivingBootstrap(bob, header.salt))
+        bob = RatchetEngine.bootstrapReceiving(bob, aliceKey, header.salt)
+
+        val result = RatchetEngine.decrypt(bob, envelope)
+        assertNotNull(result)
+        assertEquals("hello", String(result!!.second))
+    }
+
+    @Test
+    fun `bidirectional messaging`() {
+        val aliceKey = key(1); val aliceSalt = salt(1)
+        val bobKey = key(2); val bobSalt = salt(2)
+        var alice = RatchetEngine.bootstrapSending(aliceKey, aliceSalt)
+        var bob = RatchetEngine.bootstrapSending(bobKey, bobSalt)
+
+        // Alice -> Bob
+        val (a2, e1) = RatchetEngine.encrypt(alice, contactIdHash, "hi bob".toByteArray(), null, null)
+        alice = a2
+        bob = RatchetEngine.bootstrapReceiving(bob, aliceKey, aliceSalt)
+        val r1 = RatchetEngine.decrypt(bob, e1)!!
+        bob = r1.first
+        assertEquals("hi bob", String(r1.second))
+
+        // Bob -> Alice
+        val (b2, e2) = RatchetEngine.encrypt(bob, contactIdHash, "hi alice".toByteArray(), null, null)
+        bob = b2
+        alice = RatchetEngine.bootstrapReceiving(alice, bobKey, bobSalt)
+        val r2 = RatchetEngine.decrypt(alice, e2)!!
+        alice = r2.first
+        assertEquals("hi alice", String(r2.second))
+    }
+
+    @Test
+    fun `out of order delivery within window`() {
+        val aliceKey = key(1); val aliceSalt = salt(1)
+        var alice = RatchetEngine.bootstrapSending(aliceKey, aliceSalt)
+        val envelopes = (0..2).map {
+            val (next, env) = RatchetEngine.encrypt(alice, contactIdHash, "m$it".toByteArray(), null, null)
+            alice = next
+            env
+        }
+
+        var bob = RatchetEngine.bootstrapReceiving(
+            RatchetEngine.bootstrapSending(key(2), salt(2)), aliceKey, aliceSalt,
+        )
+
+        // Receive 2, then 0, then 1.
+        val r2 = RatchetEngine.decrypt(bob, envelopes[2])!!; bob = r2.first
+        val r0 = RatchetEngine.decrypt(bob, envelopes[0])!!; bob = r0.first
+        val r1 = RatchetEngine.decrypt(bob, envelopes[1])!!; bob = r1.first
+        assertEquals("m2", String(r2.second))
+        assertEquals("m0", String(r0.second))
+        assertEquals("m1", String(r1.second))
+    }
+
+    @Test
+    fun `replay of a consumed message fails`() {
+        val aliceKey = key(1); val aliceSalt = salt(1)
+        var alice = RatchetEngine.bootstrapSending(aliceKey, aliceSalt)
+        val (a2, env) = RatchetEngine.encrypt(alice, contactIdHash, "once".toByteArray(), null, null)
+        alice = a2
+        var bob = RatchetEngine.bootstrapReceiving(
+            RatchetEngine.bootstrapSending(key(2), salt(2)), aliceKey, aliceSalt,
+        )
+        val first = RatchetEngine.decrypt(bob, env)!!
+        bob = first.first
+        assertEquals("once", String(first.second))
+        assertNull(RatchetEngine.decrypt(bob, env))
+    }
+
+    @Test
+    fun `tampered header fails authentication`() {
+        val aliceKey = key(1); val aliceSalt = salt(1)
+        val alice = RatchetEngine.bootstrapSending(aliceKey, aliceSalt)
+        val (_, env) = RatchetEngine.encrypt(alice, contactIdHash, "secret".toByteArray(), null, null)
+
+        val payload = MessageEnvelope.decode(env)!!
+        // Flip a byte inside contactIdHash (offset 6: magic[4]+version[1]+flags[1]).
+        payload[6] = (payload[6] + 1).toByte()
+        val tampered = MessageEnvelope.encode(payload)
+
+        var bob = RatchetEngine.bootstrapReceiving(
+            RatchetEngine.bootstrapSending(key(2), salt(2)), aliceKey, aliceSalt,
+        )
+        assertNull(RatchetEngine.decrypt(bob, tampered))
+    }
+
+    @Test
+    fun `expired ttl is rejected`() {
+        val aliceKey = key(1); val aliceSalt = salt(1)
+        val alice = RatchetEngine.bootstrapSending(aliceKey, aliceSalt)
+        val (_, env) = RatchetEngine.encrypt(alice, contactIdHash, "fleeting".toByteArray(), 1L, null)
+
+        Thread.sleep(20)
+        val bob = RatchetEngine.bootstrapReceiving(
+            RatchetEngine.bootstrapSending(key(2), salt(2)), aliceKey, aliceSalt,
+        )
+        assertNull(RatchetEngine.decrypt(bob, env))
+    }
+
+    @Test
+    fun `wrong barcode key cannot decrypt`() {
+        val aliceKey = key(1); val aliceSalt = salt(1)
+        val alice = RatchetEngine.bootstrapSending(aliceKey, aliceSalt)
+        val (_, env) = RatchetEngine.encrypt(alice, contactIdHash, "hello".toByteArray(), null, null)
+
+        // Bob seeds the receiving chain from the wrong barcode -> wrong key.
+        val bob = RatchetEngine.bootstrapReceiving(
+            RatchetEngine.bootstrapSending(key(2), salt(2)), key(99), aliceSalt,
+        )
+        assertNull(RatchetEngine.decrypt(bob, env))
+    }
+
+    @Test
+    fun `needsReceivingBootstrap tracks salt changes`() {
+        val state = RatchetEngine.bootstrapSending(key(1), salt(1))
+        assertTrue(RatchetEngine.needsReceivingBootstrap(state, salt(5)))
+        val seeded = RatchetEngine.bootstrapReceiving(state, key(5), salt(5))
+        assertFalse(RatchetEngine.needsReceivingBootstrap(seeded, salt(5)))
+        assertTrue(RatchetEngine.needsReceivingBootstrap(seeded, salt(6)))
+    }
+}

--- a/docs/crypto/wire-format.md
+++ b/docs/crypto/wire-format.md
@@ -1,15 +1,15 @@
-# BarCodeNcrypt v5 wire format
+# BarCodeNcrypt v6 wire format
 
-This document is the canonical reference for the on-wire format of v5 encrypted messages.
-Round-trip unit tests assert against the test vector in §4.
+This document is the canonical reference for the on-wire format of v6 encrypted messages.
+Round-trip unit tests (`RatchetEngineTest`, `MessageHeaderTest`) assert against it.
 
 ## 1. Token
 
 ```
-~BCEv5~<base64>
+~BCEv6~<base64>
 ```
 
-- Prefix is the literal seven characters `~BCEv5~`.
+- Prefix is the literal seven characters `~BCEv6~`.
 - `<base64>` uses the URL-safe alphabet (`A-Z a-z 0-9 - _`) with no padding and no
   line breaks.
 - The base64 decodes to a binary payload of `[ header || ciphertext ]`.
@@ -18,24 +18,24 @@ Round-trip unit tests assert against the test vector in §4.
 
 | Field                  | Size | Notes                                                   |
 | ---------------------- | ---: | ------------------------------------------------------- |
-| `magic`                |    4 | ASCII `"BCE5"` (`0x42 0x43 0x45 0x35`)                  |
-| `version`              |    1 | `0x05`                                                  |
+| `magic`                |    4 | ASCII `"BCE6"` (`0x42 0x43 0x45 0x36`)                  |
+| `version`              |    1 | `0x06`                                                  |
 | `flags`                |    1 | bit 0: `has_ttl`, bit 1: `has_open_count`, bit 2: `dh_ratchet_step` |
 | `contactIdHash`        |   16 | First 16 bytes of `SHA-256(contact.lookupKey)`          |
+| `salt`                 |   16 | The sender's per-contact Argon2 salt                    |
 | `dhPublic`             |   32 | Sender's current X25519 public key (zero when symmetric only)  |
 | `previousChainMessages` | 4   | Message count in the previous sending chain (`pn`)      |
 | `messageNumber`        |    4 | Position within the current sending chain (`n`)         |
 | `ttlMs`                |    8 | Present iff `flags.0`                                   |
 | `openCountMax`         |    4 | Present iff `flags.1`                                   |
 | `timestampMs`          |    8 | `System.currentTimeMillis()` at encrypt time            |
-| `nonce`                |   12 | `HMAC-SHA256(mk, "BCEv5_Nonce" ‖ n_be32)[0..12)`        |
 
-Fixed header size (no flags set): **82 bytes**.
-With both TTL and `openCount`: **94 bytes**.
+Fixed header size (no flags set): **86 bytes**. With both TTL and `openCount`: **98 bytes**.
 
-The whole encoded header (bytes `0..endOfNonce`, inclusive) is fed to AES-GCM as
-`associatedData`. Flipping any bit in the header therefore fails the GCM tag, which
-the receiver surfaces as a generic decryption failure.
+The whole encoded header is fed to AES-GCM as `associatedData`. Flipping any bit in the
+header therefore fails the GCM tag, which the receiver surfaces as a generic decryption
+failure. The 96-bit GCM IV is generated randomly by the AEAD (Tink `AesGcmJce`) and is
+carried at the front of the ciphertext — it is **not** a header field.
 
 ## 3. Cryptographic construction
 
@@ -43,24 +43,28 @@ the receiver surfaces as a generic decryption failure.
 
 ```
 keyMaterial   = barcode_bytes ‖ password_bytes_or_empty
-bootstrap_key = Argon2id(keyMaterial, perContactSalt,
-                         t=3, m=64 MiB, p=2, len=32)
-rk_0  = HKDF-SHA256(bootstrap_key, info="BCEv5_Root",       len=32)
-cks_0 = HKDF-SHA256(bootstrap_key, info="BCEv5_SendChain",  len=32)
-ckr_0 = HKDF-SHA256(bootstrap_key, info="BCEv5_RecvChain",  len=32)
+bootstrap_key = Argon2id(keyMaterial, salt, t=3, m=64 MiB, p=2, len=32)
+rk_0  = HKDF-SHA256(bootstrap_key, info="BCEv6_Root",  len=32)
+ck_0  = HKDF-SHA256(bootstrap_key, info="BCEv6_Chain", len=32)
 ```
 
-Both sides bootstrap from the same `(barcode, password, salt)` triple, so the initial
-chain keys match. `perContactSalt` is 16 bytes of `SecureRandom` per contact, persisted
-in `ratchet_state.salt`.
+`salt` is 16 bytes of `SecureRandom`, generated once per contact on the **sending** side
+and carried in every outbound header. Both peers derive the **same** chain key `ck_0` from
+the same `(barcode, password, salt)` triple, so the sender's chain key for message `n`
+equals the receiver's chain key for message `n`.
+
+The path is bidirectional: each peer uses its **own** salt for its sending chain, and
+seeds a separate **receiving** chain from the salt it reads out of the first inbound
+header. Because the two salts differ, the two directions never collide on a message key
+even though both start at `n = 0`.
 
 ### 3.2 Symmetric ratchet step
 
 ```
-mk_n     = HKDF-SHA256(cks_n, info="BCEv5_MessageKey", len=32)
-cks_n+1  = HKDF-SHA256(cks_n, info="BCEv5_NextChain",  len=32)
-nonce_n  = HMAC-SHA256(mk_n, "BCEv5_Nonce" ‖ be32(n))[0..12)
-ct_n     = AES-256-GCM_encrypt(mk_n, nonce_n, plaintext, header_n)
+mk_n     = HKDF-SHA256(ck_n, info="BCEv6_MessageKey", len=32)
+ck_n+1   = HKDF-SHA256(ck_n, info="BCEv6_NextChain",  len=32)
+iv_n     = random 96-bit GCM IV (chosen by the AEAD)
+ct_n     = iv_n ‖ AES-256-GCM(mk_n, iv_n, plaintext, header_n) ‖ tag
 ```
 
 `mk_n` is single-use. The chain key advances on every encrypt and on every decrypt
@@ -70,47 +74,35 @@ ct_n     = AES-256-GCM_encrypt(mk_n, nonce_n, plaintext, header_n)
 
 ```
 dh_out         = X25519(self_priv, remote_pub)
-(rk_next, ck)  = HKDF-SHA256(salt=rk, ikm=dh_out, info="BCEv5_RkChain", len=64)
+(rk_next, ck)  = HKDF-SHA256(salt=rk, ikm=dh_out, info="BCEv6_RkChain", len=64)
                  // first 32 bytes → rk_next, second 32 → ck
 ```
 
 On `startSession(remote_pub)`, the sender derives `(rk_next, cks)` and emits the next
-message with `flags.2` set and `dhPublic` set to its freshly-generated public.
-
-A receiver that observes an unfamiliar `dhPublic` first performs an incoming DH ratchet
-step (deriving `(rk', ckr')`), then rotates its own ephemeral keypair to seed the
-sending chain.
+message with `flags.2` set and `dhPublic` set to its freshly-generated public. A receiver
+that observes an unfamiliar `dhPublic` first performs an incoming DH ratchet step, then
+rotates its own ephemeral keypair to seed the sending chain. (The DH UI is staged for
+Plan 4; v1.0 ships the symmetric path.)
 
 ### 3.4 Out-of-order delivery
 
 Receivers advance the chain to `header.messageNumber`, retaining `(dhPublic, k)` → `mk`
-entries in a bounded map (`RatchetEngine.SKIP_WINDOW = 1000`, FIFO eviction). Late
-arrivals within the window decrypt via the stored `mk` and remove the entry. Replays
-of an already-consumed `mk` fail since the entry is gone.
+entries in a bounded map (`RatchetEngine.SKIP_WINDOW = 1000`, FIFO eviction of the oldest
+entry). Late arrivals within the window decrypt via the stored `mk` and remove the entry.
+Replays of an already-consumed `mk` fail because the entry is gone and the chain has
+advanced past it.
 
 ## 4. Test vector
 
-Inputs:
-
-- `barcode      = "1234567890123"` (UTF-8 bytes)
-- `password     = null`
-- `salt         = 0x01 0x02 … 0x10` (16 bytes, byte = (i + 1) for i in 0..15)
-- `contactIdHash = 0x07` × 16
-- `plaintext    = "hello"`
-- `ttlMs        = null`
-- `openMax      = null`
-
-After bootstrap, the first encrypt produces an envelope whose decoded payload is
-**82 + 21 = 103 bytes** (16-byte GCM tag + 5-byte ciphertext = 21 bytes appended to the
-82-byte header). Round-tripping through `RatchetEngine.encrypt` then
-`RatchetEngine.decrypt` yields `"hello"`. The unit test
-`RatchetEngineTest.round trip simple message` asserts this.
-
-Decrypting the *same* envelope twice against a fresh receiver state must fail the
-second time (the chain key advanced past `n=0` after the first decrypt).
+`RatchetEngineTest.cross-device round trip` asserts the core property: Alice bootstraps a
+sending chain with salt `S_A`, encrypts `"hello"`, and Bob — who learns `S_A` from the
+header and re-derives the same Argon2 key — decrypts it to `"hello"`. A second decrypt of
+the same envelope against the advanced receiver state fails. With `plaintext = "hello"`
+and no flags, the decoded payload is `86 (header) + 12 (IV) + 5 (ct) + 16 (tag) = 119`
+bytes.
 
 ## 5. Compatibility
 
-There is no in-app v3 → v5 or v4 → v5 migration. Existing v3/v4 ciphertext will not
-decrypt under v5; the database migration `MIGRATION_10_11` drops the legacy state
-tables wholesale. v1.0 ships v5 only.
+There is no in-app v3/v4/v5 → v6 migration. Existing ciphertext will not decrypt under
+v6; `MIGRATION_11_12` drops the legacy `ratchet_state` table and rebuilds it for the v6
+schema. v6 bootstraps fresh from the next encrypt/decrypt.


### PR DESCRIPTION
## What this is

A full code audit found ~49 distinct bugs across crypto, services, the data layer, and UI. This PR fixes them in phases. **It's a draft** — I cannot build Android locally in the CI container (the SDK download is network-blocked), so I'm relying on CI to compile/test. Expect to iterate on CI failures.

## Phase 1 — crypto (this commit)

The v5 symmetric path **could never decrypt a message sent from another device**:
- the per-contact salt was random per device and never transmitted, and
- the sender encrypted with `cks` while the receiver decrypted with `ckr` (different HKDF labels), so the keys never matched.

Redesigned as a **v6** format (`~BCEv6~`):
- Sender's Argon2 salt is transmitted in the header → both devices derive the same bootstrap key. Each peer uses its own salt, so the two directions are independent (no role negotiation).
- Sending/receiving chains seed from one shared derivation → sender's key for message `n` == receiver's key for message `n`.
- Argon2 split out of `RatchetEngine` so the engine is pure and JVM-testable. **Added `RatchetEngineTest`** (the spec referenced it but it never existed) covering cross-device, bidirectional, out-of-order, replay, tamper, TTL, wrong-key.
- Dropped the dead derived-nonce field (Tink supplies a random GCM IV); hardened header bounds check.
- Repaired `MIGRATION_8_9`'s dropped `barcodes` columns and added a destructive fallback for pre-v3 schemas (`MIGRATION_11_12`, db v12).
- Scanner now resolves keys by actual decrypted value (not a 6-char hash suffix) and runs the Argon2-heavy work off the main thread.

## Still to come (subsequent commits on this branch)

- **Crashes:** ComposeView hosted in a bare Service with no ViewTree owners (overlay `hiltViewModel()` crash); accessibility node use-after-free; autofill `onFillRequest` never invoking its callback + `getWindowNodeAt(0)` IOOBE.
- **Security/data:** SQLCipher opened with an empty passphrase then cached forever (lockout); unobserved auth gate; dual divergent password stores; non-atomic open-count increment.
- **Leaks/lifecycle:** AccessibilityNodeInfo recycling, registry-token leaks, foreground-service start, scanner executor.
- **UI (the "things overlap" report):** edge-to-edge with no insets on most screens; the "Add key" FAB that opens nothing; non-scrollable overflowing columns; light theme built from `darkColorScheme()`; invisible/clashing text; nested dialogs; missing list keys.

Full findings are in the session that generated this branch.

https://claude.ai/code/session_019Py4x2cTwLNf3HD8CLibAX

---
_Generated by [Claude Code](https://claude.ai/code/session_019Py4x2cTwLNf3HD8CLibAX)_

## Summary by Sourcery

Migrate the app’s messaging crypto from the broken v5 format to a new v6 ratchet, fixing cross-device decryption and hardening persistence and scanner behavior.

New Features:
- Introduce a v6 symmetric ratchet design that supports bidirectional, cross-device messaging with per-contact salts embedded in message headers.
- Add comprehensive JVM unit tests for the ratchet and header wire format to validate cross-device, out-of-order, replay, tamper, TTL, and wrong-key behavior.

Bug Fixes:
- Fix the inability to decrypt messages sent from other devices by making both peers derive matching chain keys from a shared Argon2 bootstrap key.
- Ensure scanner-based decryption reliably finds the correct key by matching on the actual decrypted barcode value instead of a short hash suffix.
- Repair the Room schema for barcodes and ratchet state, including missing columns and an invalid v5 ratchet_state layout that could break migrations.
- Harden message header parsing and decryption to reject truncated or tampered headers without crashing or advancing ratchet state.

Enhancements:
- Refactor RatchetEngine and EncryptionManager so Argon2 key derivation is owned by the manager, making the ratchet pure and JVM-testable.
- Redesign header and envelope encoding for v6, including a new salt field, random GCM IV handling, and a simplified Base64 implementation usable from JVM tests.
- Improve ratchet state persistence to explicitly track send/receive salts, chain counters, and skipped keys with safer JSON parsing.
- Optimize key-exchange and scanner flows by reusing a placeholder QR bitmap and running heavy decryption work off the main thread.

Documentation:
- Update the crypto wire-format documentation to describe the new v6 token, header layout, symmetric ratchet, DH ratchet, and compatibility guarantees.

Tests:
- Add RatchetEngineTest and extend MessageHeaderTest to cover v6 wire-format, truncation handling, and core ratchet behaviors across multiple scenarios.